### PR TITLE
fixed github action script for master branch

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Build and push Debian Base images
         run: |
           . .github_script.sh
+          build_image Debian-Base/Core-*
+          push_image Debian-Base/Core-*
           build_image Debian-Base/*
           push_image Debian-Base/*
           rmi_without_core


### PR DESCRIPTION
Now github action on master branch cannot build images, because any app image requires core-* images on docker hub.
Fixed script to build and push core-* image at first.